### PR TITLE
pcloud or pCloud

### DIFF
--- a/example/getStarted.php
+++ b/example/getStarted.php
@@ -5,6 +5,7 @@
 require_once("../lib/pcloud/autoload.php");
 pCloud\Config::$credentialPath = "../lib/pCloud/app.cred";
 
+
 try {
 	// Create Folder instance
 


### PR DESCRIPTION
```
require_once("../lib/pcloud/autoload.php");
pCloud\Config::$credentialPath = "../lib/pCloud/app.cred";
```
That won't work  on case sensitive linux machines...
either use ```pcloud``` or ```pCloud```