### PR TITLE
fix return type on bool cases for file class, delete method

### DIFF
--- a/lib/File.php
+++ b/lib/File.php
@@ -174,7 +174,7 @@ class File
 	 * @throws Exception
 	 * @noinspection PhpUnused
 	 */
-	public function delete(int $fileId): stdClass
+	public function delete(int $fileId): stdClass|bool
 	{
 		$response = $this->request->get("deletefile", array("fileid" => $fileId));
 


### PR DESCRIPTION
on return the response in success cases it was throwing an error because of the type return defined as only stdClass, i add |bool to accept the defined bool type too